### PR TITLE
Add Tailwind config with Lava/Basalto palette

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  content: [
+    "./index.html"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        lava: '#cf1020',
+        basalto: '#606060'
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif']
+      }
+    }
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- add tailwind.config.js with custom Lava/Basalto colors
- set default font family to Inter

## Testing
- `node -v`