### PR TITLE
Add CI workflow for Tailwind build and deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: |
+          npm install tailwindcss html-validate
+      - name: Build Tailwind CSS
+        run: |
+          npx tailwindcss -m
+      - name: Validate HTML
+        run: |
+          npx html-validate index.html
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./


### PR DESCRIPTION
## Summary
- add GitHub Action to build Tailwind CSS
- validate HTML using html-validate
- deploy site to `gh-pages`

## Testing
- `true`