### PR TITLE
Add Tailwind CDN setup with brand palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,26 @@
   <meta name="description" content="Souvenirs e roupa com alma dos Açores. Marca açoriana de luxo com envio internacional. Volcano Eye Azores – a identidade das ilhas em forma de estilo.">
   <meta name="keywords" content="souvenirs açores, loja souvenirs são miguel, moda açoriana, volcano eye, presentes dos açores, recordações açorianas">
   <meta name="author" content="Volcano Eye Azores">
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Playfair+Display&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Space+Grotesk:wght@400;700&display=swap" rel="stylesheet">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            basalt: "#1a1a1a",
+            lava: "#ff3d00",
+            ash: "#e5e5e5"
+          },
+          fontFamily: {
+            inter: ["Inter", "sans-serif"],
+            spaceGrotesk: ["Space Grotesk", "sans-serif"]
+          }
+        }
+      }
+    }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="styles.css" rel="stylesheet">
   <style>
     body {
       margin: 0;
@@ -160,7 +179,7 @@
 
   <section id="contacto">
     <h2>Contacto</h2>
-    <p style="text-align: center;">Segue-nos no <a href="https://www.instagram.com/volcanoeye_souvenirs_azores/" target="_blank" style="color:#fff;">@volcanoeye_souvenirs_azores</a></p>
+    <p style="text-align: center;">Segue-nos no <a href="https://www.instagram.com/volcanoeye_souvenirs_azores/" target="_blank" >@volcanoeye_souvenirs_azores</a></p>
   </section>
 
   <footer>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-basalt text-ash font-inter;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  @apply text-lava font-spaceGrotesk;
+}
+
+a {
+  @apply text-lava hover:underline;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  theme: {
+    extend: {
+      colors: {
+        basalt: '#1a1a1a',
+        lava: '#ff3d00',
+        ash: '#e5e5e5',
+      },
+      fontFamily: {
+        inter: ['Inter', 'sans-serif'],
+        spaceGrotesk: ['Space Grotesk', 'sans-serif'],
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- load Tailwind via CDN with custom config for brand colours
- define fonts Inter and Space Grotesk
- add Tailwind base styles in `styles.css`
- remove inline colour style from instagram link

## Testing
- `npx tailwindcss -i styles.css -o output.css` *(fails: command not found)*